### PR TITLE
handle NT_STATUS_ACCESS_DENIED error

### DIFF
--- a/lib/sambal/client.rb
+++ b/lib/sambal/client.rb
@@ -105,7 +105,7 @@ module Sambal
 
     def cd(dir)
       response = ask("cd \"#{dir}\"")
-      if response.split("\r\n").join('') =~ /NT_STATUS_OBJECT_(NAME|PATH)_NOT_FOUND/
+      if response.split("\r\n").join('') =~ /NT_STATUS_/
         Response.new(response, false)
       else
         Response.new(response, true)


### PR DESCRIPTION
```
irb(main):002:0> client.cd('\test_dir\other_dir')
=> #<Sambal::Response:0x00007f3d180e8998 @message=" cd \"\\test_dir\\other_dir\"\r\n\e[?2004l\rcd \\test_dir\\other_dir\\: NT_STATUS_ACCESS_DENIED\r\n\e[?2004hsmb: \\>", @success=true>
```

Handles `NT_STATUS_ACCESS_DENIED` error

```
irb(main):001> regex = /NT_STATUS_/
=> /NT_STATUS_/
irb(main):002> " cd \"\\test_dir\\other_dir\"\r\n\e[?2004l\rcd \\test_dir\\other_dir\\: NT_STATUS_ACCESS_DENIED\r\n\e[?2004hsmb: \\>" =~ regex
=> 61
irb(main):003> " cd \"\\test_dir\\other_dir\"\r\n\e[?2004l\rcd \\test_dir\\other_dir\\: TEST\r\n\e[?2004hsmb: \\>" =~ regex
=> nil
irb(main):004> " cd \"\\test_dir\\other_dir\"\r\n\e[?2004l\rcd \\test_dir\\other_dir\\: NT_STATUS_NAME_NOT_FOUND\r\n\e[?2004hsmb: \\>" =~ regex
=> 61
irb(main):005> " cd \"\\test_dir\\other_dir\"\r\n\e[?2004l\rcd \\test_dir\\other_dir\\: NT_STATUS_PATH_NOT_FOUND\r\n\e[?2004hsmb: \\>" =~ regex
=> 61
```